### PR TITLE
Fix package name formatting in requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ matplotlib~=3.6.3
 numpy~=1.24.3
 pandas~=1.5.3
 Pillow~=10.2.0
-scikit_learn~=1.3.0
+scikit-learn~=1.3.0


### PR DESCRIPTION
In requirements.txt, the scikit-learn package was listed as scikit_learn instead. While installing with pip from the original file still works as intended, properly installing scikit-learn, some tools (e.g., IDEs) incorrectly flag the scikit-learn requirement (mentioned as dependencies of other packages) as not being installed. The persistent error message may then be ignored over time, making it easier for other errors to be uncaught during development for users of the tools that treat scikit_learn and scikit-learn as distinct passengers.

Change the package name in requirements.txt to scikit-learn, which prevents this issue from coming up. This is not intended to be a bug fix - tools that flag scikit_learn and scikit-learn as different packages should not do so. However, fixing the discrepancy minimizes possibilities of issues occurring in future development.